### PR TITLE
Exclude cali, pbr, vxlan and vnet interfaces facts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+facter (2.4.6-1+focal0+exo2) focal; urgency=medium
+
+  * Exclude Calico, Cloudstack public bridge, VXLAN and QEMU tap interfaces facts
+
+ -- Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>  Tue, 05 Apr 2022 17:06:35 +0300
+
 facter (2.4.6-1+focal0+exo1) focal; urgency=medium
 
   * Rebuild for focal.

--- a/debian/patches/0002-Exclude-cali-pbr-vxlan-vnet-interfaces-facts.patch
+++ b/debian/patches/0002-Exclude-cali-pbr-vxlan-vnet-interfaces-facts.patch
@@ -1,0 +1,31 @@
+From c033ab20cce21822a46fc21948f8a8cf09421077 Mon Sep 17 00:00:00 2001
+From: Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>
+Date: Tue, 5 Apr 2022 19:53:10 +0300
+Subject: [PATCH] Exclude cali, pbr, vxlan and vnet interfaces facts
+
+Calico, Cloudstack public bridge, VXLAN and QEMU tap interfaces
+facts are not used/referenced in Puppet codebase; let's remove
+them altogether. Unfortunately this is hardcoded in facter's code
+and not brought from a configuration file.
+---
+ lib/facter/interfaces.rb | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/facter/interfaces.rb b/lib/facter/interfaces.rb
+index ab9d9e1..f7cf49c 100644
+--- a/lib/facter/interfaces.rb
++++ b/lib/facter/interfaces.rb
+@@ -39,6 +39,10 @@ end
+
+ Facter::Util::IP.get_interfaces.each do |interface|
+
++  # Exclude Calico interface, Cloudstack public bridge interfaces,
++  # VXLAN interfaces and QEMU (vnet) tap interfaces
++  next if interface =~ /cali|pbr|vxlan|vnet/
++
+   # Make a fact for each detail of each interface.  Yay.
+   #   There's no point in confining these facts, since we wouldn't be able to create
+   # them if we weren't running on a supported platform.
+--
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Do-not-require-rubygems.patch
+0002-Exclude-cali-pbr-vxlan-vnet-interfaces-facts.patch


### PR DESCRIPTION
### Description

Calico, Cloudstack public bridge, VXLAN and QEMU tap interfaces
facts are not used/referenced in Puppet codebase; let's remove
them altogether. Unfortunately this is hardcoded in facter's code
and not brought from a configuration file.

### Testing

No more facts for Calico interfaces:
```
exoadmin@kube-node-pp001:~$ dpkg -l | grep facter
ii  facter                               2.4.6-1+focal0+exo2               all          collect and display facts about the system
exoadmin@kube-node-pp001:~$ sudo facter -p  | grep macaddress
macaddress => ee:ee:ee:ee:ee:ee
macaddress_eth0 => 06:ce:1e:00:11:97
macaddress_eth1 => 0a:c6:e2:00:09:d2
macaddress_kube_ipvs0 => ae:f1:a5:85:19:0f
```

No more facts for VXLAN and vnet interfaces:
```
exoadmin@virt-hv-pp019:~$ dpkg -l | grep facter
ii  facter                                     2.4.6-1+focal0+exo2                     all          collect and display facts about the system
ii  python-facterpy                            0.1-0+exo1                              all          dictionary-like interface to Puppet's facter utility

exoadmin@virt-hv-pp019:~$ sudo facter -p  | grep macaddress
ipmi1_macaddress => ac:1f:6b:8e:13:a3
ipmi_macaddress => ac:1f:6b:8e:13:a3
macaddress => be:ff:f2:62:e5:15
macaddress_cloud0 => be:ff:f2:62:e5:15
macaddress_eth0 => ac:1f:6b:8d:88:d8
macaddress_eth1 => ac:1f:6b:8d:88:d9
macaddress_private => 1a:cc:51:e7:d5:8b
macaddress_public => 00:00:00:00:00:00
macaddress_vlan181 => ac:1f:6b:8d:88:d9
macaddress_vlan182 => ac:1f:6b:8d:88:d9
macaddress_vlan183 => ac:1f:6b:8d:88:d8
macaddress_vlan184 => ac:1f:6b:8d:88:d8
macaddress_vlan191 => ac:1f:6b:8d:88:d9
macaddress_vlan192 => ac:1f:6b:8d:88:d9
macaddress_vlan193 => ac:1f:6b:8d:88:d8
macaddress_vlan194 => ac:1f:6b:8d:88:d8

```