### PR TITLE
Exclude cali, pbr, vxlan and vnet interfaces facts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+facter (2.4.6-1+bionic0+exo2) bionic; urgency=medium
+
+  * Exclude cali, pbr, vxlan and vnet interfaces facts
+
+ -- Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>  Thu, 07 Apr 2022 11:36:02 +0300
+
 facter (2.4.6-1+bionic0+exo1) bionic; urgency=medium
 
   * Rebuild for Bionic.

--- a/debian/patches/0002-Exclude-cali-pbr-vxlan-vnet-interfaces-facts.patch
+++ b/debian/patches/0002-Exclude-cali-pbr-vxlan-vnet-interfaces-facts.patch
@@ -1,0 +1,31 @@
+From c033ab20cce21822a46fc21948f8a8cf09421077 Mon Sep 17 00:00:00 2001
+From: Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>
+Date: Tue, 5 Apr 2022 19:53:10 +0300
+Subject: [PATCH] Exclude cali, pbr, vxlan and vnet interfaces facts
+
+Calico, Cloudstack public bridge, VXLAN and QEMU tap interfaces
+facts are not used/referenced in Puppet codebase; let's remove
+them altogether. Unfortunately this is hardcoded in facter's code
+and not brought from a configuration file.
+---
+ lib/facter/interfaces.rb | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/facter/interfaces.rb b/lib/facter/interfaces.rb
+index ab9d9e1..f7cf49c 100644
+--- a/lib/facter/interfaces.rb
++++ b/lib/facter/interfaces.rb
+@@ -39,6 +39,10 @@ end
+
+ Facter::Util::IP.get_interfaces.each do |interface|
+
++  # Exclude Calico interface, Cloudstack public bridge interfaces,
++  # VXLAN interfaces and QEMU (vnet) tap interfaces
++  next if interface =~ /cali|pbr|vxlan|vnet/
++
+   # Make a fact for each detail of each interface.  Yay.
+   #   There's no point in confining these facts, since we wouldn't be able to create
+   # them if we weren't running on a supported platform.
+--
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Do-not-require-rubygems.patch
+0002-Exclude-cali-pbr-vxlan-vnet-interfaces-facts.patch


### PR DESCRIPTION
### Description

Calico, Cloudstack public bridge, VXLAN and QEMU tap interfaces
facts are not used/referenced in Puppet codebase; let's remove
them altogether. Unfortunately this is hardcoded in facter's code
and not brought from a configuration file.

Same as https://github.com/exoscale/pkg-facter/pull/1 but a Bionic build.