### PR TITLE
debian/patch: Exclude Tailscale IPv6 addresses [focal]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+facter (2.4.6-1+focal0+exo4) focal; urgency=low
+
+  * Exclude Tailscale IPv6 addresses
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Wed, 18 Jan 2023 14:49:14 +0100
+
 facter (2.4.6-1+focal0+exo3) focal; urgency=low
 
   * Also exclude Tailscale interfaces facts

--- a/debian/patches/0003-Exclude-ipaddress-facts.patch
+++ b/debian/patches/0003-Exclude-ipaddress-facts.patch
@@ -1,0 +1,15 @@
+We do not want Tailscale IPv6 addresses to show up in Puppet realm.
+Unfortunately this can only be hardcoded in facter's code.
+
+--- a/lib/facter/ipaddress6.rb
++++ b/lib/facter/ipaddress6.rb
+@@ -28,7 +28,8 @@
+ 
+   String(output).scan(/#{token}\s?((?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/).each do |match|
+     match = match.first
+-    unless match =~ /^fe80.*/ or match == "::1"
++    # Exclude unwanted IP addresses
++    unless match =~ /^fe80.*/ or match =~ /^fd7a:115c:a1e0:ab12:.*/ or match == "::1"
+       ip = match
+       break if return_first
+     end

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0002-Exclude-interfaces-facts.patch
+0003-Exclude-ipaddress-facts.patch


### PR DESCRIPTION
https://ci.internal.exoscale.ch/job/pkg-facter/26/console