### PR TITLE
Prevent lookups in /opt/puppetlabs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+facter (2.4.6-1+focal0+exo5) focal; urgency=low
+
+  * Remove puppetlabs directory override
+
+ -- Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>  Mon, 31 Jul 2023 17:26:35 +0300
+
 facter (2.4.6-1+focal0+exo4) focal; urgency=low
 
   * Exclude Tailscale IPv6 addresses

--- a/debian/patches/0004-remove_puppetlabs_directory_override.patch
+++ b/debian/patches/0004-remove_puppetlabs_directory_override.patch
@@ -1,0 +1,19 @@
+Author: Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>
+Last-Update: 2023-07-31
+
+Prevent legacy facter from looking up in /opt/puppetlabs directory
+where modern puppet-agent binaries are placed. This was actually
+causing legacy facter to misbehave for fact `virtual` when
+`/.dockerenv` file was present on hypervisors.
+
+--- facter-2.4.6.orig/lib/facter/util/config.rb
++++ facter-2.4.6/lib/facter/util/config.rb
+@@ -80,7 +80,7 @@ module Facter::Util::Config
+     if Facter::Util::Config.is_windows?
+       @override_binary_dir = nil
+     else
+-      @override_binary_dir = "/opt/puppetlabs/puppet/bin"
++      @override_binary_dir = nil
+     end
+   end
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0002-Exclude-interfaces-facts.patch
 0003-Exclude-ipaddress-facts.patch
+0004-remove_puppetlabs_directory_override.patch


### PR DESCRIPTION
### Description

We discovered that legacy facter on Focal hypervisors was erroneously reporting `virtual` fact as `docker` when `/.dockerenv` file was presented. It turned out that facter was employing virt-what binary under /opt/puppelabs (shipped by puppet-agent 8). Prevent such lookups to minimize interference between legacy and modern agents.

### Testing

```
exoadmin@virt-hv-pp023:~$ dpkg -l | grep facter
ii  facter                                     2.4.6-1+focal0+exo4                     all          collect and display facts about the system
ii  puppet-agent                               8.1.0-1focal                            amd64        The Puppet Agent package contains all of the elements needed to run puppet, including ruby and facter.
exoadmin@virt-hv-pp023:~$ sudo facter -p > 2.4.6-1+focal0+exo4.txt

exoadmin@virt-hv-pp023:~$ sudo dpkg -i facter_2.4.6-1+focal0+exo5_all.deb 
(Reading database ... 62928 files and directories currently installed.)
Preparing to unpack facter_2.4.6-1+focal0+exo5_all.deb ...
Unpacking facter (2.4.6-1+focal0+exo5) over (2.4.6-1+focal0+exo4) ...
Setting up facter (2.4.6-1+focal0+exo5) ...
exoadmin@virt-hv-pp023:~$ dpkg -l | grep facter
ii  facter                                     2.4.6-1+focal0+exo5                     all          collect and display facts about the system
ii  puppet-agent                               8.1.0-1focal                            amd64        The Puppet Agent package contains all of the elements needed to run puppet, including ruby and facter.
exoadmin@virt-hv-pp023:~$ sudo facter -p > 2.4.6-1+focal0+exo5.txt
exoadmin@virt-hv-pp023:~$ diff -u 2.4.6-1+focal0+exo4.txt 2.4.6-1+focal0+exo5.txt 
--- 2.4.6-1+focal0+exo4.txt     2023-07-31 14:36:09.732521240 +0000
+++ 2.4.6-1+focal0+exo5.txt     2023-07-31 14:37:52.282151645 +0000
@@ -107,8 +107,8 @@
 manufacturer => Supermicro
 md127_filesystem => ext4
 
-memoryfree => 84.88 GB
-memoryfree_mb => 86913.58
+memoryfree => 84.89 GB
+memoryfree_mb => 86928.31
 memorysize => 250.44 GB
 memorysize_mb => 256445.72
 mtu_cloud0 => 1500
@@ -265,13 +265,13 @@
 swapfree_mb => 0.00
 swapsize => 0.00 MB
 swapsize_mb => 0.00
-system_uptime => {"seconds"=>30775373, "hours"=>8548, "days"=>356, "uptime"=>"356 days"}
+system_uptime => {"seconds"=>30775476, "hours"=>8548, "days"=>356, "uptime"=>"356 days"}
 timezone => UTC
 type => Other
 uniqueid => 1aac77ff
 uptime => 356 days
 uptime_days => 356
 uptime_hours => 8548
-uptime_seconds => 30775373
+uptime_seconds => 30775476
 uuid => 00000000-0000-0000-0000-0cc47af460c5
 virtual => physical
```

For `virtual`:
```
exoadmin@virt-hv-pp023:~$ sudo touch /.dockerenv
exoadmin@virt-hv-pp023:~$ sudo facter -p virtual
docker
exoadmin@virt-hv-pp023:~$ sudo dpkg -i facter_2.4.6-1+focal0+exo5_all.deb 
(Reading database ... 62928 files and directories currently installed.)
Preparing to unpack facter_2.4.6-1+focal0+exo5_all.deb ...
Unpacking facter (2.4.6-1+focal0+exo5) over (2.4.6-1+focal0+exo4) ...
Setting up facter (2.4.6-1+focal0+exo5) ...
exoadmin@virt-hv-pp023:~$ sudo facter -p virtual
physical
exoadmin@virt-hv-pp023:~$
```