### PR TITLE
Prevent lookups in /opt/puppetlabs directory

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+facter (2.4.6-1+bionic0+exo5) bionic; urgency=medium
+
+  * Remove puppetlabs directory override
+
+ -- Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>  Wed, 02 Aug 2023 15:12:36 +0300
+
 facter (2.4.6-1+bionic0+exo4) bionic; urgency=low
 
   * Exclude Tailscale IPv6 addresses

--- a/debian/patches/0004-remove_puppetlabs_directory_override.patch
+++ b/debian/patches/0004-remove_puppetlabs_directory_override.patch
@@ -1,0 +1,19 @@
+Author: Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>
+Last-Update: 2023-07-31
+
+Prevent legacy facter from looking up in /opt/puppetlabs directory
+where modern puppet-agent binaries are placed. This was actually
+causing legacy facter to misbehave for fact `virtual` when
+`/.dockerenv` file was present on hypervisors.
+
+--- facter-2.4.6.orig/lib/facter/util/config.rb
++++ facter-2.4.6/lib/facter/util/config.rb
+@@ -80,7 +80,7 @@ module Facter::Util::Config
+     if Facter::Util::Config.is_windows?
+       @override_binary_dir = nil
+     else
+-      @override_binary_dir = "/opt/puppetlabs/puppet/bin"
++      @override_binary_dir = nil
+     end
+   end
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 0001-Do-not-require-rubygems.patch
 0002-Exclude-interfaces-facts.patch
 0003-Exclude-ipaddress-facts.patch
+0004-remove_puppetlabs_directory_override.patch


### PR DESCRIPTION
Prevent lookups in /opt/puppetlabs to minimize interference between legacy and modern puppet-agent.